### PR TITLE
'Remote' is added to the global namespace

### DIFF
--- a/src/lowpro.jquery.js
+++ b/src/lowpro.jquery.js
@@ -152,7 +152,7 @@
     }
   });
 
-  Remote = $.klass({
+  var Remote = $.klass({
     initialize: function(options) {
       if (this.element.attr('nodeName') == 'FORM') this.element.attach(Remote.Form, options);
       else this.element.attach(Remote.Link, options);


### PR DESCRIPTION
'Remote' shouldn't have to be in the global namespace.
